### PR TITLE
add -a mode with only active runs, sort runs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1414214'
+ValidationKey: '1433700'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.7.4
-Date: 2022-04-29
+Version: 0.7.5
+Date: 2022-05-04
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.
 Imports: 

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -57,7 +57,11 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
       return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -c USER 1")
     } else {
       message("")
-      message("Type 'rs2 -c username DAYS' with DAYS an integer denoting how many days you want results from")
+      if (mydir %in% c("-cr", "-c") && daysback != 3) {
+        message("Type 'rs2 -a username' to get only active runs in slurm")
+      } else {
+        message("Type 'rs2 -c username DAYS' with DAYS an integer denoting how many days you want results from")
+      }
       message("")
       message("Found ", length(myruns), if (mydir == "-a") " active", " runs.",
               if (length(myruns)/as.numeric(daysback) > 20) " Excuse me? You need a cluster only for yourself it seems.")

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -9,23 +9,29 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     loopRuns(choose_folder("."), user = user)
   } else if (mydir == "-f") {
     loopRuns(dir(), user = user)
-  } else if (mydir == "-cr") {
+  } else if (mydir %in% c("-cr", "-ar")) {
     myruns <- system(paste0("squeue -u ", user, " -h -o '%Z'"), intern = TRUE)
     runnames <- system(paste0("squeue -u ", user, " -h -o '%j'"), intern = TRUE)
 
-    myruns2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format WorkDir -P -n"), intern = TRUE)
- #   myruns2<-myruns2[!grepl("^$",myruns2)]
-    myruns <- c(myruns, myruns2)
-    runnames2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format JobName -P -n"), intern = TRUE)
-#    runnames2<-runnames2[!grepl("^batch$",runnames2)]
-    runnames <- c(runnames, runnames2)
-    if (any(grepl("mag-run", runnames))) {
-      myruns <- myruns[-which(runnames %in% c("default", "batch"))]
-      runnames <- runnames[-which(runnames %in% c("default", "batch"))]
-    } else {
-      myruns <- myruns[-which(runnames %in% c("batch"))]
-      runnames <- runnames[-which(runnames %in% c("batch"))]
+    if (mydir == "-cr") {
+      myruns2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format WorkDir -P -n"), intern = TRUE)
+      # myruns2<-myruns2[!grepl("^$",myruns2)]
+      myruns <- c(myruns, myruns2)
+      runnames2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format JobName -P -n"), intern = TRUE)
+      # runnames2<-runnames2[!grepl("^batch$",runnames2)]
+      runnames <- c(runnames, runnames2)
     }
+
+    if (any(grepl("mag-run", runnames))) {
+      deleteruns <- which(runnames %in% c("default", "batch"))
+    } else {
+      deleteruns <- which(runnames %in% c("batch"))
+    }
+    if (length(deleteruns) > 0) {
+      myruns <- myruns[-deleteruns]
+      runnames <- runnames[-deleteruns]
+    }
+
     if (length(myruns) == 0) {
       return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -cr USER 1")
     }
@@ -36,6 +42,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
         next
       } else {
         coupled <- c(coupled, paste0(paste0(myruns[[i]], "/output/", runnames[[i]], "-rem-"), seq(10)))
+        coupled <- c(coupled, paste0(myruns[[i]], "/output/", runnames[[i]])) # for coupled runs in parallel mode
         rem <- c(rem, i)
       }
     }
@@ -44,7 +51,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
       myruns <- c(myruns, coupled) # add coupled paths
     }
     myruns <- myruns[file.exists(myruns)] # keep only existing paths
-    myruns <- unique(myruns[!is.na(myruns)])
+    myruns <- sort(unique(myruns[!is.na(myruns)]))
 
     if (length(myruns) == 0) {
       return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -cr USER 1")
@@ -52,7 +59,8 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
       message("")
       message("Type 'rs2 -cr username DAYS' with DAYS an integer denoting how many days you want results from")
       message("")
-      message("Found these runs")
+      message("Found ", length(myruns), if (mydir == "-ar") " active", " runs.",
+              if (length(myruns) > 40) " Excuse me? You need a cluster only for yourself it seems.")
     }
 
 #    if (length(myruns)>40) {

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -9,11 +9,11 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     loopRuns(choose_folder("."), user = user)
   } else if (mydir == "-f") {
     loopRuns(dir(), user = user)
-  } else if (mydir %in% c("-cr", "-ar")) {
+  } else if (mydir %in% c("-cr", "-a", "-c")) {
     myruns <- system(paste0("squeue -u ", user, " -h -o '%Z'"), intern = TRUE)
     runnames <- system(paste0("squeue -u ", user, " -h -o '%j'"), intern = TRUE)
 
-    if (mydir == "-cr") {
+    if (mydir %in% c("-cr", "-c")) {
       myruns2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format WorkDir -P -n"), intern = TRUE)
       # myruns2<-myruns2[!grepl("^$",myruns2)]
       myruns <- c(myruns, myruns2)
@@ -33,7 +33,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     }
 
     if (length(myruns) == 0) {
-      return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -cr USER 1")
+      return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -c USER 1")
     }
     coupled <- rem <- NULL
     for (i in 1:length(runnames)) {
@@ -54,13 +54,13 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     myruns <- sort(unique(myruns[!is.na(myruns)]))
 
     if (length(myruns) == 0) {
-      return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -cr USER 1")
+      return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -c USER 1")
     } else {
       message("")
-      message("Type 'rs2 -cr username DAYS' with DAYS an integer denoting how many days you want results from")
+      message("Type 'rs2 -c username DAYS' with DAYS an integer denoting how many days you want results from")
       message("")
-      message("Found ", length(myruns), if (mydir == "-ar") " active", " runs.",
-              if (length(myruns) > 40) " Excuse me? You need a cluster only for yourself it seems.")
+      message("Found ", length(myruns), if (mydir == "-a") " active", " runs.",
+              if (length(myruns)/as.numeric(daysback) > 20) " Excuse me? You need a cluster only for yourself it seems.")
     }
 
 #    if (length(myruns)>40) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.7.4**
+R package **modelstats**, version **0.7.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.4, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.5, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.7.4},
+  note = {R package version 0.7.5},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
I still get a bit lost in the number of old, finished runs, and therefore propose a new `-a` switch, showing only active runs. Also, sort the runs, and also cover coupled runs in parallel mode.

If that is merged, the help of `rs2` has to be extended, I guess.