### PR TITLE
rework REMIND AMT suite

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1433700'
+ValidationKey: '1452816'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.7.5
+Version: 0.7.6
 Date: 2022-05-04
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.7.5**
+R package **modelstats**, version **0.7.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.5, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.6, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.7.5},
+  note = {R package version 0.7.6},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
Combined with [REMIND PR #801](https://github.com/remindmodel/remind/pull/801), testOneRegi is added to the AMT suite. I also added the `default-AMT` to the scenarios there, so a specific treatment is not necessary anymore. SlurmConfig is also specified in the scenario config from now on. Instead of setting `cfg$force_download`, I simply deleted `input/source_files.log`, which should be feasible for MAgPIE as well, but I didn't dare to change it there. Therefore, the sleeping time is not needed anymore, because simply the first scenario that locks the model redownloads the input data.