### PR TITLE
add runtime for non-completed jobs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1433700'
+ValidationKey: '1452892'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.7.5
-Date: 2022-05-04
+Version: 0.7.6
+Date: 2022-05-05
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.
 Imports: 

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -187,8 +187,12 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
     out[i, "Runtime"] <- "NA"
     if (file.exists(fle)) {
       load(fle)
-      if (exists("stats")) if (any(grepl("GAMSEnd", names(stats)))) {
-        out[i, "Runtime"] <- format(round(stats[["timeGAMSEnd"]] - stats[["timeGAMSStart"]],1))
+      if (exists("stats")) {
+        if (any(grepl("GAMSEnd", names(stats)))) {
+          out[i, "Runtime"] <- format(round(stats[["timeGAMSEnd"]] - stats[["timeGAMSStart"]], 1))
+        } else if (any(grepl("timePrepareStart", names(stats))) & out[i, "RunStatus"] %in% c("Run in progress")) {
+          out[i, "Runtime"] <- paste0("> ", format(round(Sys.time() - stats[["timePrepareStart"]], 1)))
+        }
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.7.5**
+R package **modelstats**, version **0.7.6**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.5, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.6, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.7.5},
+  note = {R package version 0.7.6},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
if a job is not completed and still `Run in progress`, add the time difference between the preparation and now, together with a `>` sign:

```
C_d_delfrag_bIT-rem-1  8.8 hours    TRUE     nash         Normal completion   100/100           not_converged          2                    TRUE      TRUE
C_d_delfrag_bIT-rem-2  > 2.8 hours  TRUE     nash         Run in progress     35/100            222272222222           NA                   NA        FALSE
C_o_1p5c_bIT-rem-1     15.6 hours   TRUE     nash         Normal completion   100/100           not_converged          2                    TRUE      TRUE
C_o_1p5c_bIT-rem-2     > 6.9 hours  TRUE     nash         Run in progress     49/100            222222222222           NA                   NA        FALSE
```