### PR TITLE
show modelstat also during run

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1452892'
+ValidationKey: '1472317'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.7.6
-Date: 2022-05-05
+Version: 0.7.7
+Date: 2022-05-09
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.
 Imports: 

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -74,8 +74,9 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
         if (any(grepl("modelstat", names(stats)))) out[i, "modelstat"] <- stats[["modelstat"]]
         if (is.na(out[i, "modelstat"])) out[i, "modelstat"] <- "NA"
       }
-    } else {
-      if (file.exists(gdx)) out[i, "modelstat"] <- as.numeric(readGDX(gdx, "o_modelstat", format = "first_found"))
+    }
+    if (out[i, "modelstat"] == "NA" && file.exists(gdx)) {
+      out[i, "modelstat"] <- as.numeric(readGDX(gdx, "o_modelstat", format = "first_found"))
     }
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.7.6**
+R package **modelstats**, version **0.7.7**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.6, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.7, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.7.6},
+  note = {R package version 0.7.7},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
If `runstatistics.rda` exists, but doesn't contain modelstat because not is still running, take it from `fulldata.gdx`