### PR TITLE
adapt modeltests.R to shorter run reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1472317'
+ValidationKey: '1492218'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.7.7
-Date: 2022-05-09
+Version: 0.7.8
+Date: 2022-05-19
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.
 Imports: 

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -145,10 +145,13 @@ if (model == "REMIND" & compScen == TRUE) write(paste0("Each run folder below sh
     write(paste0("The test of ", format(Sys.time(), "%Y-%m-%d"), " contains these merges:"), myfile, append = TRUE)
     write(commits, myfile, append = TRUE)
 #    write(paste0("View merge range on github: https://github.com/",model,"model/",model",/pulls?q=is%3Apr+is%3Amerged+",lastCommit,"..",commit),myfile,append=TRUE)
-    write("Run                                Runtime              jobInSlurm          RunType            RunStatus         Iter             Conv            modelstat      Mif           runInAppResults", myfile, append = TRUE)
+    colSep <- "  "
+    coltitles <- c("Run                               ", "Runtime    ", "inSlurm", "RunType    ", "RunStatus         ",
+                   "Iter            ", "Conv                 ", "modelstat          ", "Mif     ", "inAppResults")
+    write(paste(coltitles, collapse = colSep), myfile, append = TRUE)
     for (i in paths) {
       grsi <- getRunStatus(i)
-      write(sub("\n$", "", printOutput(grsi, 34)), myfile, append = TRUE)
+      write(sub("\n$", "", printOutput(grsi, lenCols = nchar(coltitles), colSep = colSep)), myfile, append = TRUE)
       if (model == "REMIND") if (grsi[,"Conv"] != "converged") errorList <- c(errorList,"Some run(s) did not converge")
       if (model == "MAgPIE") if (grsi[,"Iter"] != "y2100")  errorList <- c(errorList,"Some run(s) did not converge")
       if (grsi[,"Mif"] != "TRUE") errorList <- c(errorList,"Some run(s) did not report correctly")

--- a/R/printOutput.R
+++ b/R/printOutput.R
@@ -27,7 +27,7 @@ printOutput <- function(string, len1stcol = 67, lenCols = NULL, colSep = "   ") 
   string <- templ
   for (i in 1:length(string)) {
     out <- paste0(formatstr(unname(string)[[i]],
-           ifelse(i >= length(lenCols), i + 12, lenCols[length(string) + 2 - i])), colSep, out)
+           ifelse(i >= length(lenCols), i + 12, lenCols[length(string) + 2 - i])), ifelse(is.null(lenCols), "", colSep), out)
   }
   return(paste0(formatstr(rownames(string), len1stcol), colSep, out, "\n"))
 #  if(is.data.frame(string)) print(unname(string))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.7.7**
+R package **modelstats**, version **0.7.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.7, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.7.8, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.7.7},
+  note = {R package version 0.7.8},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
fixing the broken layout of the AMT mail

I could only partly test it, but I took the respective lines from the write command and used `message` to print them, and everything aligned well.