### PR TITLE
Bugfix reading modelstat for aborted runs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1595924'
+ValidationKey: '1615572'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.3.2
+    rev: v0.3.2.9001
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.8.3
-Date: 2022-08-24
+Version: 0.8.4
+Date: 2022-08-29
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.
 Imports: 

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -72,7 +72,7 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
         if (any(grepl("modelstat", names(stats)))) out[i, "modelstat"] <- paste0(as.character(stats[["modelstat"]]), collapse = "")
         if (is.na(out[i, "modelstat"])) out[i, "modelstat"] <- "NA"
       } else {
-        if (any(grepl("modelstat", names(stats)))) out[i, "modelstat"] <- stats[["modelstat"]]
+        if (any(grepl("modelstat", names(stats)))) try(out[i, "modelstat"] <- stats[["modelstat"]], silent = TRUE)
         if (is.na(out[i, "modelstat"])) out[i, "modelstat"] <- "NA"
       }
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.8.3**
+R package **modelstats**, version **0.8.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.8.3, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.8.4, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.8.3},
+  note = {R package version 0.8.4},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
When a run is aborted, `modelstat` has a `numeric(0)` value in the `runstatistics.rda` file, which was causing a bug in the reading of `modelstat` of `rs2`