### PR TITLE
add rs2 command line argument -t to show status of current automated REMIND tests

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1615572'
+ValidationKey: '1732230'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.8.4
-Date: 2022-08-29
+Version: 0.9.0
+Date: 2022-09-12
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools which allow to analyze model runs.
 Imports: 

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -11,6 +11,11 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     loopRuns(if (length(chosendirs) == 0) "exit" else chosendirs, user = user)
   } else if (mydir == "-f") {
     loopRuns(dir(), user = user)
+  } else if (mydir == "-t") {
+    amtPath <- "/p/projects/remind/modeltests/output/"
+    amtPattern <- readRDS("/p/projects/remind/modeltests/runcode.rds")
+    amtDirs<-paste0(amtPath, dir(path = amtPath, pattern = amtPattern))
+    loopRuns(amtDirs, user = user)
   } else if (mydir %in% c("-cr", "-a", "-c")) {
     myruns <- system(paste0("squeue -u ", user, " -h -o '%Z'"), intern = TRUE)
     runnames <- system(paste0("squeue -u ", user, " -h -o '%j'"), intern = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.8.4**
+R package **modelstats**, version **0.9.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.8.4, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.9.0, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.8.4},
+  note = {R package version 0.9.0},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
Running `rs2 -t` on PIK's cluster will show the status of the most recent REMIND AMT runs. Useful if the weekly email is not delivered due to the calibration test run taking longer than expected.