### PR TITLE
version bump for renv in modeltests update

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1793598'
+ValidationKey: '1814576'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: ${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            ${{ runner.os }}-usr-local-lib-R-
+            2-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,7 +1,7 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.9.3",
-  "description": "<p>A collection of tools which allow to analyze model runs.<\/p>",
+  "version": "0.9.4",
+  "description": "<p>A collection of tools to analyze model runs.<\/p>",
   "creators": [
     {
       "name": "Giannousakis, Anastasis"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.9.3
-Date: 2022-10-21
+Version: 0.9.4
+Date: 2022-11-08
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.9.3**
+R package **modelstats**, version **0.9.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
 ## Purpose and Functionality
 
-A collection of tools which allow to analyze model runs.
+A collection of tools to analyze model runs.
 
 
 ## Installation
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.9.3, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.9.4, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.9.3},
+  note = {R package version 0.9.4},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```

--- a/man/modelstats-package.Rd
+++ b/man/modelstats-package.Rd
@@ -6,7 +6,7 @@
 \alias{modelstats-package}
 \title{modelstats: Run Analysis Tools}
 \description{
-A collection of tools which allow to analyze model runs.
+A collection of tools to analyze model runs.
 }
 \seealso{
 Useful links:


### PR DESCRIPTION
I accidentally pushed the code change directly to pik-piam/modelstats thus this PR contains only the version increment