### PR TITLE
if rs2 is run in output subdirectory, show results of this run

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1814576'
+ValidationKey: '1835115'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "<p>A collection of tools to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.9.4
-Date: 2022-11-08
+Version: 0.9.5
+Date: 2022-11-21
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -151,7 +151,7 @@ if (model == "REMIND" & compScen == TRUE) write(paste0("Each run folder below sh
     write(commits, myfile, append = TRUE)
 
     colSep <- "  "
-    coltitles <- c("Run                               ", "Runtime    ", "inSlurm", "RunType    ", "RunStatus         ",
+    coltitles <- c("Run                                       ", "Runtime    ", "", "RunType    ", "RunStatus         ",
                    "Iter            ", "Conv                 ", "modelstat          ", "Mif     ", "inAppResults")
     write(paste(coltitles, collapse = colSep), myfile, append = TRUE)
     for (i in paths) {

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -6,9 +6,13 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
   if (mydir == ".") {
     loopRuns(".", user = user)
   } else if (mydir == "") {
-    dirs <- list.dirs(".", recursive = FALSE)
-    chosendirs <- gms::chooseFromList(dirs, type = "folders")
-    loopRuns(if (length(chosendirs) == 0) "exit" else chosendirs, user = user)
+    if (all(file.exists(c("full.gms", "log.txt", "config.Rdata", "prepare_and_run.R")))) {
+      loopRuns(".")
+    } else {
+      dirs <- c(".", list.dirs(".", recursive = FALSE))
+      chosendirs <- gms::chooseFromList(dirs, type = "folders")
+      loopRuns(if (length(chosendirs) == 0) "exit" else chosendirs, user = user)
+    }
   } else if (mydir == "-f") {
     loopRuns(dir(), user = user)
   } else if (mydir == "-t") {
@@ -40,7 +44,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     }
 
     if (length(myruns) == 0) {
-      return("No runs found for this user. To change the reporting period (days) of the tool you need to specify also a user, e.g. rs2 -c USER 1")
+      return(paste0("No runs found for this user. You can change the reporting period (here: 5 days) by running 'rs2 -c ", user, " 5"))
     }
     coupled <- rem <- NULL
     for (i in 1:length(runnames)) {

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -7,7 +7,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     loopRuns(".", user = user)
   } else if (mydir == "") {
     if (all(file.exists(c("full.gms", "log.txt", "config.Rdata", "prepare_and_run.R")))) {
-      loopRuns(".")
+      loopRuns(".", user = user)
     } else {
       dirs <- c(".", list.dirs(".", recursive = FALSE))
       chosendirs <- gms::chooseFromList(dirs, type = "folders")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.9.4**
+R package **modelstats**, version **0.9.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.9.4, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.9.5, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2022},
-  note = {R package version 0.9.4},
+  note = {R package version 0.9.5},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
If I'm in an output subdirectory and run `rs2`, I get:
```
Please choose folders:

1: all
2: ./EDGE-T
3: ./magicc
4: ./renv
5: Search by pattern...
```
Nonsense :)

After this PR, if `rs2` is started with no further qualifiers and `full.gms`, `log.txt`, `config.Rdata`, `prepare_and_run.R` exist in the current folder, it assumes this is a run folder and shows the result of this run. And in the selection process, you can now not only select the subfolders, but also the current folder itself (`.`).