### PR TITLE
Refactor AMT

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1857120'
+ValidationKey: '1936300'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/lucode2-check.yaml
+++ b/.github/workflows/lucode2-check.yaml
@@ -28,6 +28,7 @@ jobs:
           curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
           chmod 0755 run.sh
           ./run.sh bootstrap
+          rm -f bspm_*.tar.gz
 
       - name: Enable r-universe repo, modify bspm integration
         run: |
@@ -48,6 +49,7 @@ jobs:
                 pkgs <- c(bspm::install_sys(pkgs[!pkgs %%in%% noBinaryInstallRPackages]),
                           pkgs[pkgs %%in%% noBinaryInstallRPackages])
               }
+              type <- "source"
             })
             trace(utils::install.packages, expr, print = FALSE)
           })
@@ -67,9 +69,9 @@ jobs:
         uses: pat-s/always-upload-cache@v3
         with:
           path: /usr/local/lib/R/
-          key: 2-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
+          key: 3-${{ runner.os }}-usr-local-lib-R-${{ hashFiles('DESCRIPTION') }}
           restore-keys: |
-            2-${{ runner.os }}-usr-local-lib-R-
+            3-${{ runner.os }}-usr-local-lib-R-
 
       - name: Restore R library permissions
         run: |

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "<p>A collection of tools to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.9.6
-Date: 2022-12-19
+Version: 0.10.0
+Date: 2023-01-06
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 
@@ -24,5 +24,5 @@ URL: https://github.com/pik-piam/modelstats
 BugReports: https://github.com/pik-piam/modelstats/issues
 Encoding: UTF-8
 License: LGPL-3
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 VignetteBuilder: knitr

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -259,7 +259,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
         lastRun <- NULL
         lastRun <- max(sameRuns[sameRuns < sub("output/", "", cfg$results_folder)])
         currentRunTime <- as.numeric(.readRuntime("."), units = "hours")
-        lastRunTime <- as.numeric(.readRuntime(paste0("../", lastRun), units = "hours"))
+        lastRunTime <- as.numeric(.readRuntime(paste0("../", lastRun)), units = "hours")
         if (currentRunTime > (1.25 * lastRunTime)) {
           errorList <- c(errorList, "Check runtime! Have some scenarios become slower?")
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.9.6**
+R package **modelstats**, version **0.10.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/ui#builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2022). _modelstats: Run Analysis Tools_. R package version 0.9.6, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.10.0, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,8 +55,8 @@ A BibTeX entry for LaTeX users is
 @Manual{,
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
-  year = {2022},
-  note = {R package version 0.9.6},
+  year = {2023},
+  note = {R package version 0.10.0},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```

--- a/man/modeltests.Rd
+++ b/man/modeltests.Rd
@@ -13,7 +13,8 @@ modeltests(
   iamccheck = TRUE,
   email = TRUE,
   compScen = TRUE,
-  mattermostToken = NULL
+  mattermostToken = NULL,
+  gitPath = "/p/system/packages/git/2.16.1/bin/git"
 )
 }
 \arguments{
@@ -35,6 +36,8 @@ The test parameter needs to be of the form "YY-MM-DD"}
 \item{compScen}{whether compScen has to run or not}
 
 \item{mattermostToken}{token used for mattermost notifications}
+
+\item{gitPath}{Path to the git executable}
 }
 \description{
 Runs a group of tests for a specific model. A "config/scenario_config_AMT.csv" file


### PR DESCRIPTION
I tried to understand the AMT code, in the process I refactored much of it. It now has considerably fewer linter warnings, too.

Also, I added a sleep into a busy wait to not 100% one core of the login node unnecessarily in magpie tests.

I can't really test the changes anywhere, so I guess I'll just put them into production?