### PR TITLE
show PENDING in column inSlurm if run has not started yet

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1979922'
+ValidationKey: '2000672'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "title": "modelstats: Run Analysis Tools",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "<p>A collection of tools to analyze model runs.<\/p>",
   "creators": [
     {

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.10.2
-Date: 2023-02-23
+Version: 0.10.3
+Date: 2023-03-08
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/foundInSlurm.R
+++ b/R/foundInSlurm.R
@@ -5,7 +5,7 @@
 #' @param mydir Path to the folder(s) where the run(s) is(are) performed
 #' @param user the user whose runs will be sought for
 #'
-#' @author Anastasis Giannousakis
+#' @author Anastasis Giannousakis, Oliver Richters
 #' @importFrom gdx readGDX
 #' @export
 foundInSlurm <- function(mydir = ".", user = NULL) {
@@ -17,12 +17,13 @@ foundInSlurm <- function(mydir = ".", user = NULL) {
     suppressWarnings(mydir <- normalizePath(mydir))
   }
 
-
-  if (any(grepl(mydir, system(paste0("/p/system/slurm/bin/squeue -h -o '%j %Z'"), intern = TRUE)))) {
-    return(TRUE)
+  squeueresult <- system(paste0("/p/system/slurm/bin/squeue -h -o '%j %Z %T %q' -u ", user), intern = TRUE)
+  squeueresult <- grep(mydir, squeueresult, value = TRUE)
+  if (length(squeueresult) == 1 && grepl("PENDING [A-Za-z]*$", squeueresult)) {
+    return(paste("PD", rev(strsplit(squeueresult, " ")[[1]])[[1]]))
+  } else if (length(squeueresult) > 0) {
+    return("TRUE")
   } else {
-    return(FALSE)
+    return("FALSE")
   }
-
-
 }

--- a/R/loopRuns.R
+++ b/R/loopRuns.R
@@ -63,6 +63,8 @@ loopRuns <- function(mydir, user = NULL) {
     } else {
       if (grepl("Run in progress", out)) {
         cat(cyan(out))
+      } else if (grepl("  PD ", out)) {
+        cat(yellow(out))
       } else if (grepl("not_converged|Execution erro|Compilation er|missing|interrupted|Intermed Infes", out)) {
         cat(red(out))
       } else if (grepl(" converged|Clb_converged", out)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.10.2**
+R package **modelstats**, version **0.10.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.10.2, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.10.3, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.10.2},
+  note = {R package version 0.10.3},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```

--- a/man/foundInSlurm.Rd
+++ b/man/foundInSlurm.Rd
@@ -15,5 +15,5 @@ foundInSlurm(mydir = ".", user = NULL)
 Is the run found in SLURM?
 }
 \author{
-Anastasis Giannousakis
+Anastasis Giannousakis, Oliver Richters
 }


### PR DESCRIPTION
- show `PD` in column `inSlurm` if run has not started yet together with a shortcut of the `qos` used.

looks like this:
``` bash
h_ndc_EUR_import_tax_050_2023-03-08_17.39.54       > 37.9 mins  TRUE     nash         Run in progress     1/100             NA                     NA                   NA        FALSE
h_ndc_EUR_import_tax_100_2023-03-08_17.40.19       > 58.2 mins  TRUE     nash         Run in progress     2/100             NA                     2: Locally Optimal   NA        FALSE
h_ndc_EUR_import_tax_100_oil_2023-03-08_17.40.56   NA           PD shor  nash         full.log missing    NA                NA                     NA                   NA        NA
h_ndc_EUR_import_tax_200_2023-03-08_17.40.37       NA           PD shor  nash         full.log missing    NA                NA                     NA                   NA        NA
o_1p5c_EUR_import_tax_050_2023-03-08_17.41.16      NA           PD shor  nash         full.log missing    NA                NA                     NA                   NA        NA
o_1p5c_EUR_import_tax_100_2023-03-08_17.41.35      > 57 mins    TRUE     nash         Run in progress     2/100             NA                     2: Locally Optimal   NA        FALSE
o_1p5c_EUR_import_tax_100_oil_2023-03-08_17.42.12  NA           PD shor  nash         full.log missing    NA                NA                     NA                   NA        NA
o_1p5c_EUR_import_tax_200_2023-03-08_17.41.54      NA           PD shor  nash         full.log missing    NA                NA                     NA                   NA        NA
o_lowdem_plus3_2023-03-08_16.29.31                 > 2.1 hours  TRUE     nash         Run in progress     1/100             NA                     NA                   NA        FALSE
```