### PR TITLE
bugfix modeltests, stating too many scenarios were never started

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2199658'
+ValidationKey: '2219694'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.11.3
-date-released: '2023-04-19'
+version: 0.11.4
+date-released: '2023-04-24'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.11.3
-Date: 2023-04-19
+Version: 0.11.4
+Date: 2023-04-24
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -130,7 +130,7 @@ startRuns <- function(test, model, mydir, gitPath, user) {
                              comment.char = "#",
                              na.strings = "")
       runsToStart <- selectScenarios(settings = settings, interactive = FALSE, startgroup = "AMT")
-      row.names(runsToStart) <- paste0("AMT-", row.names(runsToStart))
+      row.names(runsToStart) <- paste0(row.names(runsToStart), "-AMT")
       saveRDS(runsToStart, file = paste0(mydir, "/runsToStart.rds"))
     } else if (model == "MAgPIE") {
       # default run to download input data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.11.3**
+R package **modelstats**, version **0.11.4**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.11.3, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.11.4, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.11.3},
+  note = {R package version 0.11.4},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- Mika [changed](https://github.com/remindmodel/remind/blob/develop/start.R#L43) the `titletag=AMT` such that it is appended, not prepended.
- bug leads to the false claim that many scenarios were not started

![image](https://user-images.githubusercontent.com/90761609/233922613-3973d35f-a182-4e60-8f8c-7fa3f0b8316e.png)
