### PR TITLE
Bugfix regarding the working directory

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2280213'
+ValidationKey: '2300882'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.11.7
-date-released: '2023-05-12'
+version: 0.11.8
+date-released: '2023-05-22'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.11.7
-Date: 2023-05-12
+Version: 0.11.8
+Date: 2023-05-22
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 
@@ -15,7 +15,8 @@ Imports:
     utils,
     magclass,
     remind2,
-    gms
+    gms,
+    withr
 Suggests:
     covr,
     knitr,

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -43,7 +43,7 @@ modeltests <- function(
   setwd(mydir)
   
   message("\n=========================================================
-  Begin of AMT procedure ", format(Sys.time(), "%d-%m-%Y %H:%M:%S"), " in ", mydir, 
+  Begin of AMT procedure ", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), " in ", mydir, 
   "\n=========================================================\n")
 
   if (readLines("../.testsstatus") == "start") {

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -182,7 +182,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
 
   # wait for all AMT runs to finish
   if (!test) {
-    message(format(Sys.time(), "%d-%m-%Y %H:%M:%S"), " - waiting for all AMT runs to finish.")
+    message(format(Sys.time(), "%Y-%m-%d %H:%M:%S"), " - waiting for all AMT runs to finish.")
     repeat {
       jobsInSlurm <- system(paste0("/p/system/slurm/bin/squeue -u ", user,
                                    " -h -o '%i %q %T %C %M %j %V %L %e %Z'"), intern = TRUE)

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -191,7 +191,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
         break
       }
     }
-    message(format(Sys.time(), "%d-%m-%Y %H:%M:%S"), " - all AMT runs finished.")
+    message(format(Sys.time(), "%Y-%m-%d %H:%M:%S"), " - all AMT runs finished.")
   }
 
   message("Compiling the README.md to be committed to testing_suite repo.")  

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -43,7 +43,7 @@ modeltests <- function(
   setwd(mydir)
   
   message("\n=========================================================
-  Begin of AMT procedure ", format(Sys.Date(), "%Y-%m-%d"), " in ", mydir, 
+  Begin of AMT procedure ", format(Sys.time(), "%d-%m-%Y %H:%M:%S"), " in ", mydir, 
   "\n=========================================================\n")
 
   if (readLines("../.testsstatus") == "start") {
@@ -182,7 +182,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
 
   # wait for all AMT runs to finish
   if (!test) {
-    message(format(Sys.Date(), "%Y-%m-%d"), " - waiting for all AMT runs to finish.")
+    message(format(Sys.time(), "%d-%m-%Y %H:%M:%S"), " - waiting for all AMT runs to finish.")
     repeat {
       jobsInSlurm <- system(paste0("/p/system/slurm/bin/squeue -u ", user,
                                    " -h -o '%i %q %T %C %M %j %V %L %e %Z'"), intern = TRUE)
@@ -191,7 +191,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
         break
       }
     }
-    message(format(Sys.Date(), "%Y-%m-%d"), " - all AMT runs finished.")
+    message(format(Sys.time(), "%d-%m-%Y %H:%M:%S"), " - all AMT runs finished.")
   }
 
   message("Compiling the README.md to be committed to testing_suite repo.")  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.11.7**
+R package **modelstats**, version **0.11.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.11.7, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.11.8, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.11.7},
+  note = {R package version 0.11.8},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- Bugfix: use `withr::with_dir("output",...` instead of `setwd("output)` to ensure the correct path after the execution of `evaluateRuns()`
- move file `.testsstatus` from model folders (remind or magpie) to the respective parent folder, from where the modeltest are actually started and where also the logfiles are written.
- move code chunk that retrieves `paths` down to where `paths` is actually used.
- add hours and seconds to the timestamp in some log messages
