### PR TITLE
improve logging of coupled runs, increase space in title col for AMT

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27567888'
+ValidationKey: '27591651'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.14.12
-date-released: '2023-06-16'
+version: 0.14.13
+date-released: '2023-06-19'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.14.12
-Date: 2023-06-16
+Version: 0.14.13
+Date: 2023-06-19
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/foundInSlurm.R
+++ b/R/foundInSlurm.R
@@ -20,12 +20,14 @@ foundInSlurm <- function(mydir = ".", user = NULL) {
   squeueresult <- system("/p/system/slurm/bin/squeue -h -o '%u %Z %j %M %T %q'", intern = TRUE)
   squeuefiltered <- grep(mydir, squeueresult, value = TRUE, fixed = TRUE)
   squeuefiltered <- grep(runname, squeuefiltered, value = TRUE, fixed = TRUE)
+  # try to find REMIND slurm job corresponding to coupled MAgPIE run
   if (length(squeuefiltered) == 0 && grepl("^C_.*-mag-[0-9]+$", runname)) {
     runrem <- gsub("-mag-", "-rem-", runname)
     squeuefiltered <- grep(runrem, squeueresult, value = TRUE, fixed = TRUE)
-    if (length(squeuefiltered) > 0) return("REMIND?")
+    squeuefiltered <- grep(dirname(mydir), squeuefiltered, value = TRUE, fixed = TRUE)
+    # if (length(squeuefiltered) > 0) return("REMIND")
   }
-  if (length(squeuefiltered) > 0) {
+  if (length(squeuefiltered) == 1) {
     time <- rev(strsplit(squeuefiltered, " ")[[1]])[[3]]
     qos <- rev(strsplit(squeuefiltered, " ")[[1]])[[1]]
     yourrun <- any(grepl(paste0("^", user, " "), squeuefiltered))
@@ -37,6 +39,8 @@ foundInSlurm <- function(mydir = ".", user = NULL) {
       runuser <- strsplit(squeuefiltered, " ")[[1]][[1]]
       return(paste0(runuser, startup, pending))
     }
+  } else if (length(squeuefiltered) > 1) {
+    return("yes")
   } else {
     return("no")
   }

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -202,11 +202,11 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
   write("```", myfile)
   write(paste0("This is the result of the automated ", model, " testing suite on ",
                format(Sys.time(), "%Y-%m-%d"), "."), myfile, append = TRUE)
-  write(paste0("Path to runs:", mydir, "output/"), myfile, append = TRUE)
+  write(paste0("Path to runs: ", mydir, "output/"), myfile, append = TRUE)
   if (model == "REMIND") {
     write(paste0(c("Responsibilities:",
                    "  Robert     : SSP2EU-EU21",
-                   "  Jess / Olli: SSP2EU",
+                   "  Jess / Oli: SSP2EU",
                    "  Bjoern     : SDP",
                    "             : SSP1",
                    "             : SSP5"), collapse = "\n"), myfile, append = TRUE)
@@ -218,7 +218,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
     write(paste0("Each run folder below should contain a compareScenarios PDF comparing the output of the current and",
                  " the last successful tests (comp_with_RUN-DATE.pdf)"), myfile, append = TRUE)
   }
-  write(paste0("Note: 'Mif' = FALSE indicates a possible error in output generation, please check!"),
+  write(paste0("Note: 'Mif' = 'no' indicates a possible error in output generation, please check!"),
         myfile, append = TRUE)
   write(paste0("If you are currently viewing the email: Overview of the last test is in red, ",
                "and of the current test in green"), myfile, append = TRUE)
@@ -228,7 +228,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
 
   colSep <- "  "
   coltitles <- c(
-    "Run                                        ", "Runtime    ", "", "RunType    ", "RunStatus         ",
+    "Run                                          ", "Runtime    ", "", "RunType    ", "RunStatus         ",
     "Iter            ", "Conv                 ", "modelstat          ", "Mif     ", "inAppResults"
   )
   write(paste(coltitles, collapse = colSep), myfile, append = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.14.12**
+R package **modelstats**, version **0.14.13**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.14.12, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.14.13, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.14.12},
+  note = {R package version 0.14.13},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- if you run rs2 in magpie folder, try to find the corresponding REMIND slurm job
- for MAgPIE, show convergence progress during run instead of `NA`
- show when REMIND runs reporting
- increase space in title col for AMT to avoid directory names being cut
- add `-p` = piam mode that shows all coupled REMIND runs + MAgPIE runs from magpie/output subfolder