### PR TITLE
fix that -rem-1 runs are stated as running if -rem-10 is running

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27709435'
+ValidationKey: '27730408'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.14.17
-date-released: '2023-07-17'
+version: 0.14.18
+date-released: '2023-07-18'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.14.17
-Date: 2023-07-17
+Version: 0.14.18
+Date: 2023-07-18
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/foundInSlurm.R
+++ b/R/foundInSlurm.R
@@ -19,7 +19,7 @@ foundInSlurm <- function(mydir = ".", user = NULL) {
 
   squeueresult <- system("/p/system/slurm/bin/squeue -h -o '%u %Z %j %M %T %q'", intern = TRUE)
   squeuefiltered <- grep(mydir, squeueresult, value = TRUE, fixed = TRUE)
-  squeuefiltered <- grep(runname, squeuefiltered, value = TRUE, fixed = TRUE)
+  squeuefiltered <- grep(paste0(runname, " "), squeuefiltered, value = TRUE, fixed = TRUE)
   # try to find REMIND slurm job corresponding to coupled MAgPIE run
   if (length(squeuefiltered) == 0 && grepl("^C_.*-mag-[0-9]+$", runname)) {
     runrem <- gsub("-mag-", "-rem-", runname)

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -20,6 +20,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
   colors <- ! any(grepl("-.*b.*", mydir))
   if (isTRUE(mydir == "-t")) {
     amtPath <- "/p/projects/remind/modeltests/remind/output/"
+    cat("Results from", amtPath, "\n")
     amtPattern <- if (is.null(user) || user == "") readRDS("/p/projects/remind/modeltests/remind/runcode.rds") else user
     amtDirs <- dir(path = amtPath, pattern = amtPattern, full.names = TRUE)
     loopRuns(amtDirs, user = NULL, colors = colors)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.14.17**
+R package **modelstats**, version **0.14.18**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.14.17, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.14.18, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.14.17},
+  note = {R package version 0.14.18},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
For coupled and standalone runs, this is the output of `/p/system/slurm/bin/squeue -h -o '%u %Z %j %M %T %q'`:
```
username /p/tmp/remind/ C_d_strain_d95high-rem-10 17:39:49 RUNNING priority
username /p/tmp/remind/output/h_cpol_2023-07-18_11.37.03 h_cpol 4:47 RUNNING priority
```
So I simply check for an additional blank after the runname to make sure it works. Notice that [this line](https://github.com/pik-piam/modelstats/blob/master/R/foundInSlurm.R#L22) matches the third part (C_d_strain_d95high-rem-10) for coupled runs, while for standalone, it matches the folder.