### PR TITLE
for modeltests, identify correctly whether testOneRegi failed

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '27791918'
+ValidationKey: '27818586'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.14.21
-date-released: '2023-07-20'
+version: 0.14.22
+date-released: '2023-07-25'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.14.21
-Date: 2023-07-20
+Version: 0.14.22
+Date: 2023-07-25
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -262,13 +262,13 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
     grsi <- getRunStatus(i)
     write(sub("\n$", "", printOutput(grsi, lenCols = lenCols, colSep = colSep)), myfile, append = TRUE)
     if (model == "REMIND") {
-      if (grsi[, "RunType"] != "Calib_nash" && grsi[, "Conv"] %in% c("converged", "converged (had INFES)") && ! grepl("testOneRegi", i)) {
+      if (grsi[, "RunType"] != "Calib_nash" && grsi[, "Conv"] %in% c("converged", "converged (had INFES)") && ! grepl("1Regi|testOneRegi", i)) {
         errorList <- c(errorList, "Some run(s) did not converge")
       }
       if (grsi[, "RunType"] == "Calib_nash" && grsi[, "Conv"] != "Clb_converged") {
         errorList <- c(errorList, "Some run(s) did not converge")
       }
-      if (grsi[, "modelstat"] != "2: Locally Optimal" && grepl("testOneRegi", i)) {
+      if (grsi[, "modelstat"] != "2: Locally Optimal" && grepl("1Regi|testOneRegi", i)) {
         errorList <- c(errorList, "testOneRegi does not return an optimal solution")
       }
     } else if (model == "MAgPIE") {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.14.21**
+R package **modelstats**, version **0.14.22**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.14.21, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.14.22, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.14.21},
+  note = {R package version 0.14.22},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- After renaming `testOneRegi` to `1Regi EUR`, the check was not adapted, yet, leading to a false positive for testOneRegi not converging [here](https://gitlab.pik-potsdam.de/REMIND/testing_suite/-/commit/a197a2f6c2d17fc6e477cc79c0e519801db18f5e).