### PR TITLE
correctly identify whether default scenario converged

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2959751'
+ValidationKey: '2979808'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.15.1
-date-released: '2023-09-01'
+version: 0.15.2
+date-released: '2023-09-04'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.15.1
-Date: 2023-09-01
+Version: 0.15.2
+Date: 2023-09-04
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.
 Imports: 

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -328,7 +328,7 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
   if (model == "REMIND") {
     # Find and print runs not started
     if (length(paths) < length(rownames(runsToStart)) + 1) {
-      runsNotStarted <- setdiff(c("default-AMT-", rownames(runsToStart)), sub("_.*", "", paths))
+      runsNotStarted <- setdiff(c("default-AMT", rownames(runsToStart)), sub("_.*", "", paths))
       write(" ", myfile, append = TRUE)
       write(paste0("These scenarios did not start at all:"), myfile, append = TRUE)
       write(runsNotStarted, myfile, append = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.15.1**
+R package **modelstats**, version **0.15.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.15.1, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.15.2, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.15.1},
+  note = {R package version 0.15.2},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
`default-AMT-` [is stated not to have converged](https://gitlab.pik-potsdam.de/REMIND/testing_suite/-/commit/89bc5b6e9a589440c4331d50e535aa0611385365#8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_51_57), while in fact it is just called `default-AMT`. Fixing that.