### PR TITLE
also print human-readable Runtime in modeltests

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2979808'
+ValidationKey: '2999412'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.15.2
+version: 0.15.3
 date-released: '2023-09-04'
 abstract: A collection of tools to analyze model runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.15.2
+Version: 0.15.3
 Date: 2023-09-04
 Authors@R: c(person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")))
 Description: A collection of tools to analyze model runs.

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -263,6 +263,9 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
   message("Starting analysis for the list of the following runs:\n", paste0(paths, collapse = "\n"))
   for (i in paths) {
     grsi <- getRunStatus(i)
+    if ("Runtime" %in% names(grsi) && is.numeric(grsi[["Runtime"]])) {
+      grsi["Runtime"] <- format(round(make_difftime(second = grsi[["Runtime"]]), 1))
+    }
     write(sub("\n$", "", printOutput(grsi, lenCols = lenCols, colSep = colSep)), myfile, append = TRUE)
     if (model == "REMIND") {
       if (grsi[, "RunType"] != "Calib_nash" && grsi[, "Conv"] %in% c("converged", "converged (had INFES)") && ! grepl("1Regi|testOneRegi", i)) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.15.2**
+R package **modelstats**, version **0.15.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.15.2, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A (2023). _modelstats: Run Analysis Tools_. R package version 0.15.3, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis},
   year = {2023},
-  note = {R package version 0.15.2},
+  note = {R package version 0.15.3},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- [printing it in seconds here is not a good idea, I think](https://gitlab.pik-potsdam.de/REMIND/testing_suite/-/commit/89bc5b6e9a589440c4331d50e535aa0611385365#8ec9a00bfd09b3190ac6b22251dbb1aa95a0579d_51_57)
- was caused by #66