### PR TITLE
expand short mode (-s) to non-coupled, fix search for coupled

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29615630'
+ValidationKey: '29644309'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.15.10
-date-released: '2023-09-13'
+version: 0.15.11
+date-released: '2023-09-19'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.15.10
-Date: 2023-09-13
+Version: 0.15.11
+Date: 2023-09-19
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/foundInSlurm.R
+++ b/R/foundInSlurm.R
@@ -13,7 +13,7 @@ foundInSlurm <- function(mydir = ".", user = NULL) {
   if (is.null(user)) user <- Sys.info()[["user"]]
   suppressWarnings(mydir <- normalizePath(mydir))
   runname <- basename(mydir)
-  if (grepl("C_.*-(rem|mag)-[0-9]+$", mydir)) {
+  if (grepl("-(rem|mag)-[0-9]+$", mydir)) {
     mydir <- dirname(dirname(mydir))
   }
 

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -49,13 +49,24 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     if (isTRUE(mydir %in% "-p") && dir.exists(file.path("magpie", "output"))) folders <- c(folders, file.path("magpie", "output"))
     dirs <- NULL
     for (folder in folders) {
-      fdirs <- mixedsort(grep("^C_.*-(rem|mag)-[0-9]+$", basename(list.dirs(folder, recursive = FALSE)), value = TRUE), scientific = FALSE, numeric.type = "decimal")
+      fdirs <- mixedsort(grep("-(rem|mag)-[0-9]+$", basename(list.dirs(folder, recursive = FALSE)), value = TRUE), scientific = FALSE, numeric.type = "decimal")
       if (isTRUE(mydir %in% "-p")) {
         dirs <- c(dirs, file.path(folder, fdirs))
       } else { # -s shows only last run
         lastdirs <- NULL
         for (r in unique(gsub("-(rem|mag)-[0-9]+$", "", fdirs))) {
           lastdirs <- c(lastdirs, fdirs[min(which(gsub("-(rem|mag)-[0-9]+$", "", fdirs) == r))])
+        }
+        dirs <- c(dirs, file.path(folder, lastdirs))
+      }
+      fdirs <- grep("-(rem|mag)-[0-9]+$", basename(list.dirs(folder, recursive = FALSE)), value = TRUE, invert = TRUE)
+      fdirs <- fdirs[mixedorder(gsub("-", "", fdirs), scientific = FALSE, numeric.type = "decimal")]
+      if (isTRUE(mydir %in% "-p")) {
+        dirs <- c(dirs, file.path(folder, fdirs))
+      } else {
+        lastdirs <- NULL
+        for (r in unique(gsub("_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}\\.[0-9]{2}\\.[0-9]{2}$", "", fdirs))) {
+          lastdirs <- c(lastdirs, fdirs[max(which(gsub("_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{2}\\.[0-9]{2}\\.[0-9]{2}$", "", fdirs) == r))])
         }
         dirs <- c(dirs, file.path(folder, lastdirs))
       }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.15.10**
+R package **modelstats**, version **0.15.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2023). _modelstats: Run Analysis Tools_. R package version 0.15.10, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2023). _modelstats: Run Analysis Tools_. R package version 0.15.11, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2023},
-  note = {R package version 0.15.10},
+  note = {R package version 0.15.11},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- if you changed the prefix from `C_` to something else, the slurm job was not found anymore
- `rs2 -s` now also shows non-coupled runs, but only the most recent