### PR TITLE
fix AMT 'did runs converge' message

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29663928'
+ValidationKey: '29703216'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.15.12
-date-released: '2023-09-19'
+version: 0.15.13
+date-released: '2023-10-02'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.15.12
-Date: 2023-09-19
+Version: 0.15.13
+Date: 2023-10-02
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -268,13 +268,13 @@ evaluateRuns <- function(model, mydir, gitPath, compScen, email, mattermostToken
     }
     write(sub("\n$", "", printOutput(grsi, lenCols = lenCols, colSep = colSep)), myfile, append = TRUE)
     if (model == "REMIND") {
-      if (grsi[, "RunType"] != "Calib_nash" && grsi[, "Conv"] %in% c("converged", "converged (had INFES)") && ! grepl("1Regi|testOneRegi", i)) {
+      if (! grepl("Calib_nash|testOneRegi", grsi[, "RunType"]) && ! grsi[, "Conv"] %in% c("converged", "converged (had INFES)")) {
         errorList <- c(errorList, "Some run(s) did not converge")
       }
       if (grsi[, "RunType"] == "Calib_nash" && grsi[, "Conv"] != "Clb_converged") {
         errorList <- c(errorList, "Some run(s) did not converge")
       }
-      if (grsi[, "modelstat"] != "2: Locally Optimal" && grepl("1Regi|testOneRegi", i)) {
+      if (grepl("testOneRegi", grsi[, "RunType"]) && grsi[, "modelstat"] != "2: Locally Optimal") {
         errorList <- c(errorList, "testOneRegi does not return an optimal solution")
       }
     } else if (model == "MAgPIE") {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.15.12**
+R package **modelstats**, version **0.15.13**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2023). _modelstats: Run Analysis Tools_. R package version 0.15.12, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2023). _modelstats: Run Analysis Tools_. R package version 0.15.13, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2023},
-  note = {R package version 0.15.12},
+  note = {R package version 0.15.13},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- was surprised where [the "Some run(s) did not converge" complaint](https://gitlab.pik-potsdam.de/REMIND/testing_suite/-/blob/14aad5ea5330cf33dcff6c3e3816653d61400657/README.md) came from
- well, `not converged` should be if the RunStatus is *not* `converged`
- match `testOneRegi` on Runtype, not directory name (was not the problem, but is better anyway, I think)