### PR TITLE
fix Clb_converged, don't remove 'b' from folder names

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '29703216'
+ValidationKey: '29765240'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Test coverage
         shell: Rscript {0}
-        run: covr::codecov(quiet = FALSE)
+        run: |
+          nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
+          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.15.13
-date-released: '2023-10-02'
+version: 0.15.14
+date-released: '2023-10-30'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.15.13
-Date: 2023-10-02
+Version: 0.15.14
+Date: 2023-10-30
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -228,7 +228,9 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
     if ((isTRUE(grepl("Calib", out[i, "RunType"])) || isTRUE(cfg$gms$CES_parameters == "calibrate")) && file.exists(logtxt)) {
       calibiter <- tail(suppressWarnings(system(paste0("grep 'CES calibration iteration' ", logtxt, " |  grep -Eo  '[0-9]{1,2}'"), intern = TRUE)), n = 1)
       if (isTRUE(as.numeric(calibiter) > 0)) out[i, "Iter"] <- paste0(out[i, "Iter"], " ", "Clb: ", calibiter)
-      if (isTRUE(out[i, "Conv"] == "converged") && length(system(paste0("find ", ii, " -name 'input_*.gdx'"), intern = TRUE)) > 10) {
+      if (isTRUE(out[i, "Conv"] %in% c("converged", "converged (had INFES)")) &&
+          (length(system(paste0("find ", ii, " -name 'fulldata_*.gdx'"), intern = TRUE)) > 10 ||
+           length(system(paste0("find ", ii, " -name 'input_*.gdx'"), intern = TRUE)) > 10)) {
         out[i, "Conv"] <- "Clb_converged"
       }
     }

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -17,7 +17,7 @@
 #'
 promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
   mydir <- strsplit(mydir, ',')[[1]]
-  colors <- ! any(grepl("-.*b.*", mydir))
+  colors <- ! any(grepl("^-.*b.*", mydir))
   if (isTRUE(mydir == "-t")) {
     amtPath <- "/p/projects/remind/modeltests/remind/output/"
     cat("Results from", amtPath, "\n")
@@ -28,7 +28,7 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
   }
   if (is.null(user) || user == "") user <- Sys.info()[["user"]]
   if (daysback == "") daysback <- 3
-  if (isFALSE(colors)) mydir <- gsub("b", "", mydir)
+  if (isFALSE(colors) && grepl("^-[a-zA-Z]+", mydir)) mydir <- gsub("b", "", mydir)
   if (isTRUE(mydir == ".")) {
     loopRuns(".", user = user, colors = colors)
   } else if (length(mydir) == 0 || isTRUE(mydir == "")) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.15.13**
+R package **modelstats**, version **0.15.14**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2023). _modelstats: Run Analysis Tools_. R package version 0.15.13, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2023). _modelstats: Run Analysis Tools_. R package version 0.15.14, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2023},
-  note = {R package version 0.15.13},
+  note = {R package version 0.15.14},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- since a while, calibrations show no `Clb_converged` anymore, but just `converged`. This [misleads AMT runs](https://gitlab.pik-potsdam.de/REMIND/testing_suite/-/commit/7fe464aa5d137328f3105633a77859bc4f4bf1da) into thinking some run did not converge
- Did we have `input_02.gdx` etc. until ~ September 2022? The amount of `input_xx.gdx` files was used to determine whether a converged iteration was a successful calibration. Now, look for the corresponding `fulldata_xx.gdx` which did not seem to exist earlier.
- fix a small bug if you manually pass a folder that contains a `b` `(with `rs2 SSP2-base`), that was sometimes removed.