### PR TITLE
REMIND: Check for summation errors and report in already existing `Mif` column of `getRunStatus`

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '3581447'
+ValidationKey: '3760100'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.18.1
-date-released: '2024-03-05'
+version: 0.19.0
+date-released: '2024-03-08'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.18.1
-Date: 2024-03-05
+Version: 0.19.0
+Date: 2024-03-08
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -128,12 +128,12 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
       } else {
         miffile    <- paste0(ii, "/REMIND_generic_", cfg[["title"]], ".mif")
         sumErrFile <- paste0(ii, "/REMIND_generic_", cfg[["title"]], "_summation_errors.csv")
-        if (file.exists(sumErrFile)){ 
-          out[i, "Mif"] <- "sumErr"
-        } else if (file.exists(miffile)){
-          out[i, "Mif"] <- "yes"
-        } else {
+        if (! file.exists(miffile)){ 
           out[i, "Mif"] <- "no"
+        } else if (file.exists(sumErrFile)){
+          out[i, "Mif"] <- "sumErr"
+        } else {
+          out[i, "Mif"] <- "yes"
         }
       }
     }

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -126,8 +126,15 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
         miffile <- paste0(ii, "/validation.mif")
         out[i, "Mif"] <- if (file.exists(miffile) && file.info(miffile)[["size"]] > 99999) "yes" else "no"
       } else {
-        miffile <- paste0(ii, "/REMIND_generic_", cfg[["title"]], ".mif")
-        out[i, "Mif"] <- if (file.exists(miffile) && file.info(miffile)[["size"]] > 3899999) "yes" else "no"
+        miffile    <- paste0(ii, "/REMIND_generic_", cfg[["title"]], ".mif")
+        sumErrFile <- paste0(ii, "/REMIND_generic_", cfg[["title"]], "_summation_errors.csv")
+        if (file.exists(sumErrFile)){ 
+          out[i, "Mif"] <- "sumErr"
+        } else if (file.exists(miffile)){
+          out[i, "Mif"] <- "yes"
+        } else {
+          out[i, "Mif"] <- "no"
+        }
       }
     }
 

--- a/R/loopRuns.R
+++ b/R/loopRuns.R
@@ -43,11 +43,11 @@ loopRuns <- function(mydir, user = NULL, colors = TRUE, sortbytime = TRUE) {
   if (file.exists("/p")) {
     coltitles <- c(paste0("Folder", paste(rep(" ", len - 6), collapse = "")),
       "Runtime    ", "inSlurm ", "RunType    ", "RunStatus        ", "Iter            ",
-      "Conv                 ", "modelstat            ", "Mif", "AppResults")
+      "Conv                 ", "modelstat            ", "Mif   ", "AppResults")
     lenCols <- c(nchar(coltitles)[-length(coltitles)], 3)
   } else {
     coltitles <- c(paste0("Folder", paste(rep(" ", len - 6), collapse = "")),
-      "Runtime    ", "RunType    ", "RunStatus        ", "Mif",
+      "Runtime    ", "RunType    ", "RunStatus        ", "Mif   ",
       "Conv                 ", "Iter            ", "modelstat          ")
     lenCols <- nchar(coltitles)
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.18.1**
+R package **modelstats**, version **0.19.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.18.1, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.19.0, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.18.1},
+  note = {R package version 0.19.0},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
For REMIND model: if a `REMIND_generic<scenname>_summation_errors.csv` exists in the individual run folder, report `sumErr` in the `Mif` column of `getRunStatus`. This will be displayed also in `rs2` and added to the summary message of the AMTs.

```
Folder                                            Runtime      inSlurm   RunType      RunStatus          Iter              Conv                   modelstat              Mif     AppResults 
default-AMT_2024-03-01_22.08.46                   NA           no        nash         Abort 12R*5*Infes  5/100             566555550555           6: Intermed Infes      no      no
SDP_MC-NDC-AMT_2024-03-02_06.06.48                NA           no        nash         Abort 10R*5*Infes  5/100             000500000050           5: Locally Infes       no      no
SDP_MC-NPi-AMT_2024-03-01_22.13.42                6 hours      no        nash         Normal completion  53/100            converged              2: Locally Optimal     sumErr  yes
```