### PR TITLE
Dont start `default-AMT` twice

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4314177'
+ValidationKey: '4334058'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.21.7
+version: 0.21.8
 date-released: '2024-06-07'
 abstract: A collection of tools to analyze model runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.21.7
+Version: 0.21.8
 Date: 2024-06-07
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -134,6 +134,10 @@ startRuns <- function(test, model, mydir, gitPath, user) {
                              row.names = 1,
                              comment.char = "#",
                              na.strings = "")
+                             
+      # Source everything from scripts/start so that all functions are available everywhere
+      invisible(sapply(list.files("scripts/start", pattern = "\\.R$", full.names = TRUE), source))
+      selectScenarios <- NA # just to avoid buildLibrary to fail with "no visible global function definition for 'selectScenarios'"
       runsToStart <- selectScenarios(settings = settings, interactive = FALSE, startgroup = "AMT")
       row.names(runsToStart) <- paste0(row.names(runsToStart), "-AMT")
       saveRDS(runsToStart, file = paste0(mydir, "/runsToStart.rds"))

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -115,14 +115,9 @@ startRuns <- function(test, model, mydir, gitPath, user) {
     deleteEmptyRealizationFolders()
 
     if (model == "REMIND") {
-      message("Configuring and starting single default-AMT")
-      # Change title before starting the default run
-      system(paste0("sed -i 's/cfg$title <- ", '"default"/cfg$title <- "default-AMT"/', "' config/default.cfg"))
-      # set the slurmConfig before sourcing start.R to avoid questions about the slurm config
-      slurmConfig <- "--qos=priority --nodes=1 --tasks-per-node=12"  # nolint: object_usage_linter
-      selectScenarios <- NA  # will be loaded when sourcing start.R
-      source("start.R", local = TRUE)
-      Sys.sleep(100) # it would be much better to properly wait for the data downloading to finish
+      message("Configuring and starting single testOneRegi-AMT")
+      system(paste("Rscript start.R --testOneRegi titletag=AMT",
+                   "slurmConfig=\"--qos=priority --nodes=1 --tasks-per-node=1 --wait\""))
 
       message("Configuring and starting bundle of AMT runs")
       # do not download input data every run, reset force_download

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.21.7**
+R package **modelstats**, version **0.21.8**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.7, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.8, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.21.7},
+  note = {R package version 0.21.8},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
Start `testOneRegi-AMT` as first AMT run (before starting AMTs from scenario_config.csv to also trigger the input data download) instead of starting `default-AMT`. The latter will be started as part of the full REMIND model tests (test_05-default.R). So far it was started twice. The first one (`testOneRegi-AMT`) was removed from the list of AMT runs in the scenario_config.csv so it will be started only once.