### PR TITLE
remove hardcoded C_ prefix of REMIND-MAgPIE runs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4355472'
+ValidationKey: '41967900'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.21.9
-date-released: '2024-06-14'
+version: 0.21.10
+date-released: '2024-06-16'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.21.9
-Date: 2024-06-14
+Version: 0.21.10
+Date: 2024-06-16
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/foundInSlurm.R
+++ b/R/foundInSlurm.R
@@ -21,7 +21,7 @@ foundInSlurm <- function(mydir = ".", user = NULL) {
   squeuefiltered <- grep(mydir, squeueresult, value = TRUE, fixed = TRUE)
   squeuefiltered <- grep(paste0(runname, " "), squeuefiltered, value = TRUE, fixed = TRUE)
   # try to find REMIND slurm job corresponding to coupled MAgPIE run
-  if (length(squeuefiltered) == 0 && grepl("^C_.*-mag-[0-9]+$", runname)) {
+  if (length(squeuefiltered) == 0 && grepl("-mag-[0-9]+$", runname)) {
     runrem <- gsub("-mag-", "-rem-", runname)
     squeuefiltered <- grep(paste0(runrem, " "), squeueresult, value = TRUE, fixed = TRUE)
     squeuefiltered <- grep(dirname(mydir), squeuefiltered, value = TRUE, fixed = TRUE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.21.9**
+R package **modelstats**, version **0.21.10**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.9, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.10, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.21.9},
+  note = {R package version 0.21.10},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- make sure other prefixes work as well
- should be sufficient to identify a magpie run by `-mag-1` etc. at the end
- FYI @dklein-pik 