### PR TITLE
make sure also -mag-1 shows progress correctly

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '41967900'
+ValidationKey: '41987790'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.21.10
+version: 0.21.11
 date-released: '2024-06-16'
 abstract: A collection of tools to analyze model runs.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.21.10
+Version: 0.21.11
 Date: 2024-06-16
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -207,7 +207,7 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
         if (length(startmag) > length(endmag)) {
           fulllogmag <- gsub("-rem-", "-mag-", gsub("output", file.path("magpie", "output"), fulllog))
           loopmag <- NULL
-          if (isTRUE(cfg$gms$cm_MAgPIE_coupling == "on") && file.exists(fulllogmag)) {
+          if (file.exists(fulllogmag)) {
             suppressWarnings(try(loopmag <- sub("^.*.= ", "", system(paste0("grep 'LOOPS' ", fulllogmag, " | tail -1"), intern = TRUE)), silent = TRUE))
           }
           out[i, "RunStatus"] <- paste("Run MAgPIE", loopmag)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.21.10**
+R package **modelstats**, version **0.21.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.10, <URL: https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.11, <URL: https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.21.10},
+  note = {R package version 0.21.11},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
as `-rem-1` has `cfg$gms$cm_MAgPIE_coupling == "off"`. Not sure why [I implemented this differentiation](https://github.com/pik-piam/modelstats/pull/55/files), it seems to make no sense.