### PR TITLE
fix sacct call in 'rs2 -c'

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42088500'
+ValidationKey: '42121096'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.21.15
-date-released: '2024-06-26'
+version: 0.21.16
+date-released: '2024-07-02'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.21.15
-Date: 2024-06-26
+Version: 0.21.16
+Date: 2024-07-02
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -80,12 +80,9 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     runnames <- system(paste0("squeue -u ", user, " -h -o '%j'"), intern = TRUE)
 
     if (all(mydir %in% c("-cr", "-c"))) {
-      myruns2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format WorkDir -P -n"), intern = TRUE)
-      # myruns2<-myruns2[!grepl("^$",myruns2)]
-      myruns <- c(myruns, myruns2)
-      runnames2 <- system(paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " --format JobName -P -n"), intern = TRUE)
-      # runnames2<-runnames2[!grepl("^batch$",runnames2)]
-      runnames <- c(runnames, runnames2)
+      sacctcode <- paste0("sacct -u ", user, " -s cd,f,cancelled,timeout,oom -S ", as.Date(format(Sys.Date(), "%Y-%m-%d")) - as.numeric(daysback), " -E now -P -n")
+      myruns   <- c(myruns,   system(paste(sacctcode, "--format WorkDir"), intern = TRUE))
+      runnames <- c(runnames, system(paste(sacctcode, "--format JobName"), intern = TRUE))
     }
 
     if (any(grepl("mag-run", runnames))) {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.21.15**
+R package **modelstats**, version **0.21.16**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.15, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.16, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.21.15},
+  note = {R package version 0.21.16},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
Somehow, the behavior of `sacct` has changed for `sacct -u laurinko -S 2024-06-01 -s completed -v | head`

old cluster:
```
sacct: Jobs eligible from Sat Jun 01 00:00:00 2024 - Now
```
new cluster:
```
sacct: Jobs COMPLETED in the time window from Sat Jun 01 00:00:00 2024 to Sat Jun 01 00:00:01 2024
```
