### PR TITLE
don't complain about conopt if latest gdx is written <15 min ago

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42121096'
+ValidationKey: '42147353'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.21.16
-date-released: '2024-07-02'
+version: 0.21.17
+date-released: '2024-07-05'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.21.16
-Date: 2024-07-02
+Version: 0.21.17
+Date: 2024-07-05
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/getRunStatus.R
+++ b/R/getRunStatus.R
@@ -182,7 +182,9 @@ getRunStatus <- function(mydir = dir(), sort = "nf", user = NULL) {
           gridfiles <- Sys.glob(file.path(ii, "225*", "grid*", "gmsgrid.log"))
           if (length(gridfiles) > 0) {
             conoptdelay <- round(difftime(Sys.time(), max(file.info(gridfiles)$mtime), units = "hours") - 0.049, 1)
-            if (conoptdelay > 0) out[i, "RunStatus"] <- paste0("conoptspy >", niceround(conoptdelay, 1), "h")
+            gdxdelay <- 1
+            if (length(latest_gdx) > 0 && file.exists(latest_gdx)) gdxdelay <- difftime(Sys.time(), file.info(latest_gdx)$mtime, units = "hours")
+            if (conoptdelay > 0.1 && gdxdelay > 0.25) out[i, "RunStatus"] <- paste0("conoptspy >", niceround(conoptdelay, 1), "h")
           }
         }
       } else {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.21.16**
+R package **modelstats**, version **0.21.17**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.16, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.17, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.21.16},
+  note = {R package version 0.21.17},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- somehow, sometimes some grid files can still be found in the 225a folder
- when doing calculations such as MAGICC7 between the iteration, it might think that conopt stalled while everything is fine.
- don't complain about conopt if latest gdx was written <15 min ago