### PR TITLE
shorten REMIND AMT slurm runtime

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '42272800'
+ValidationKey: '42381822'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
+    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.21.20
-date-released: '2024-08-05'
+version: 0.21.21
+date-released: '2024-09-16'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.21.20
-Date: 2024-08-05
+Version: 0.21.21
+Date: 2024-09-16
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -115,7 +115,7 @@ startRuns <- function(test, model, mydir, user) {
     if (model == "REMIND") {
       message("Configuring and starting single testOneRegi-AMT")
       system(paste("Rscript start.R --testOneRegi titletag=AMT",
-                   "slurmConfig=\"--qos=priority --nodes=1 --tasks-per-node=1 --wait\""))
+                   "slurmConfig=\"--qos=priority --nodes=1 --tasks-per-node=1 --wait --time=2:00:00\""))
 
       message("Configuring and starting bundle of AMT runs")
       # do not download input data every run, reset force_download
@@ -123,7 +123,7 @@ startRuns <- function(test, model, mydir, user) {
 
       # now start actual test runs
       system(paste0("Rscript start.R ",
-                    "startgroup=AMT titletag=AMT slurmConfig=\"--qos=standby --nodes=1 --tasks-per-node=12\" ",
+                    "startgroup=AMT titletag=AMT slurmConfig=\"--qos=standby --nodes=1 --tasks-per-node=12 --time=36:00:00\" ",
                     "config/scenario_config.csv"))
 
       # Create and save a list of runs that should have been started in order to determine later which runs were not started

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.21.20**
+R package **modelstats**, version **0.21.21**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats)  [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.20, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2024). _modelstats: Run Analysis Tools_. R package version 0.21.21, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -56,7 +56,7 @@ A BibTeX entry for LaTeX users is
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
   year = {2024},
-  note = {R package version 0.21.20},
+  note = {R package version 0.21.21},
   url = {https://github.com/pik-piam/modelstats},
 }
 ```


### PR DESCRIPTION
- currently, all runs are started with 7 days runtime
- I want to avoid that cluster outages in a week hamper AMT runs
- It seems like the longest run is always `SSP2-NPi-calibrate-AMT`, and `rs2 -t SSP2-NPi-calibrate-AMT` shows it is regularly in the order of 15 hours
- So I took a very conservative approach of setting it to 36 hours, but I'm fine with shorter times if you prefer that