### PR TITLE
let rs2 support regular expressions for matching folders

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4462422'
+ValidationKey: '4484084'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,6 +44,13 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
+      - name: Run pre-commit checks
+        shell: bash
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
+
       - name: Verify validation key
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
 ci:
-    autoupdate_schedule: quarterly
+    autoupdate_schedule: weekly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.22.2
-date-released: '2025-01-13'
+version: 0.22.3
+date-released: '2025-01-20'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.22.2
-Date: 2025-01-13
+Version: 0.22.3
+Date: 2025-01-20
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/promptAndRun.R
+++ b/R/promptAndRun.R
@@ -124,7 +124,13 @@ promptAndRun <- function(mydir = ".", user = NULL, daysback = 3) {
     print(myruns[1:min(100, length(myruns))])
     loopRuns(myruns, user = user, colors = colors, sortbytime = FALSE)
   } else {
-    loopRuns(ifelse(dir.exists(mydir), mydir, file.path("output", mydir)), user = user, colors = colors)
+    mydir <- ifelse(! dir.exists(mydir) & dir.exists(file.path("output", mydir)), file.path("output", mydir), mydir)
+    if (! all(dir.exists(mydir))) {
+      folder <- if (sum(file.exists(c("output", "output.R", "start.R", "main.gms"))) == 4) "./output" else "."
+      mydir <- c(mydir[dir.exists(mydir)],
+                 grep(paste0(mydir[! dir.exists(mydir)], collapse = "|"), list.dirs(folder, recursive = FALSE), value = TRUE))
+    }
+    loopRuns(mydir, user = user, colors = colors, sortbytime = FALSE)
   }
 
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.22.2**
+R package **modelstats**, version **0.22.3**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats) [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2025). "modelstats: Run Analysis Tools." Version: 0.22.2, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2025). "modelstats: Run Analysis Tools." Version: 0.22.3, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,9 +55,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
-  date = {2025-01-13},
+  date = {2025-01-20},
   year = {2025},
   url = {https://github.com/pik-piam/modelstats},
-  note = {Version: 0.22.2},
+  note = {Version: 0.22.3},
 }
 ```


### PR DESCRIPTION
- Every `mydir` that is not found is used to match runs.
- So you can use `rs2 SSP2-Base,C_NPi-rem-` to match all NPi coupled runs and all SSP2-Base runs.