### PR TITLE
Remove test-mode. Change keywords defining the teststatus

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '4715100'
+ValidationKey: '4737835'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.23.4
-date-released: '2025-03-03'
+version: 0.23.5
+date-released: '2025-03-14'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.23.4
-Date: 2025-03-03
+Version: 0.23.5
+Date: 2025-03-14
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.23.4**
+R package **modelstats**, version **0.23.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/modelstats)](https://cran.r-project.org/package=modelstats) [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2025). "modelstats: Run Analysis Tools." Version: 0.23.4, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2025). "modelstats: Run Analysis Tools." Version: 0.23.5, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,9 +55,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
-  date = {2025-03-03},
+  date = {2025-03-14},
   year = {2025},
   url = {https://github.com/pik-piam/modelstats},
-  note = {Version: 0.23.4},
+  note = {Version: 0.23.5},
 }
 ```

--- a/man/modeltests.Rd
+++ b/man/modeltests.Rd
@@ -9,7 +9,6 @@ modeltests(
   gitdir = NULL,
   model = NULL,
   user = NULL,
-  test = NULL,
   email = TRUE,
   compScen = TRUE,
   mattermostToken = NULL
@@ -23,9 +22,6 @@ modeltests(
 \item{model}{Model name}
 
 \item{user}{the user that starts the job and commits the changes}
-
-\item{test}{Use this option to run a test of the workflow (no runs will be submitted)
-The test parameter needs to be of the form "YY-MM-DD"}
 
 \item{email}{whether an email notification will be send or not}
 

--- a/modelstats.Rproj
+++ b/modelstats.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: ce6ecce0-7b6f-45a0-ba31-c92a4e011fbe
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
I removed the test mode (activated whit `modeltests(test=TRUE, ...`)) as it was not used anymore.

More important: I replaced the keywords describing the current status of the modeltests with (hopefully) clearer keywords. Using these keyword the status is saved as plain text to `.teststatus`. The keywords now describe what will happen the next time `modeltests()` is called. I replaced:

start -> next:start
end -> next:evaluate
wait -> evaluateRuns() is running or stopped due to an error

In case you agree and approve, please don't forget to update the keywords in your `.teststatus` file!