### PR TITLE
Update colors in `rs` table

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6029647'
+ValidationKey: '6051696'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,42 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      # We fix this to 4.5, as currently, pre-commit hooks do not
-      # work reliably with 4.6 because of Rcpp not building reliably
-      # on 4.6. When this is resolved, the version constraint should
-      # be removed again.
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-          r-version: 4.5
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
-
+      - name: Install package and dependencies
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
+          
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.29.3
-date-released: '2026-05-06'
+version: 0.29.4
+date-released: '2026-05-11'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.29.3
-Date: 2026-05-06
+Version: 0.29.4
+Date: 2026-05-11
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")
@@ -35,3 +35,4 @@ Encoding: UTF-8
 License: LGPL-3
 VignetteBuilder: knitr
 Config/roxygen2/version: 8.0.0
+RoxygenNote: 7.3.3

--- a/R/commandLineInterface.R
+++ b/R/commandLineInterface.R
@@ -1,9 +1,9 @@
 #' Provide a command line interface to loopRuns and getSanityChecks
-#' 
+#'
 #' This function is made to be called by the rs tool. It takes the command line arguments
-#' supplied by the user when calling rs, evaluates them, and according to them prepares the 
+#' supplied by the user when calling rs, evaluates them, and according to them prepares the
 #' arguments finally passed to loopRuns or getSanityChecks.
-#' 
+#'
 #' @param argv A character vector containing the command line arguments.
 #' @returns A string containing the status or sanity table.
 #' @importFrom optparse make_option OptionParser parse_args
@@ -29,7 +29,7 @@ commandLineInterface <- function(argv) {
   is.mainfolder <- function(dir) {
     return(sum(file.exists(paste0(dir, "/", c("output", "output.R", "start.R", "main.gms")))) == 4)
   }
-  
+
   # ================================================
   #  Define command line arguments, help, and hints
   # ================================================
@@ -71,7 +71,7 @@ commandLineInterface <- function(argv) {
 
   epilogue <- c(
     "Bugs and feedback: https://github.com/pik-piam/modelstats/issues")
-    
+
   hints <- c(
     "Show (l)ast iterations of (m)agpie-coupled runs with: rs -ml",
     "Show all (m)agpie-coupled runs with: rs -m",
@@ -97,8 +97,10 @@ commandLineInterface <- function(argv) {
   arguments <- parse_args(opt_parser, args = argv, positional_arguments = c(0,1))
 
   # print hint
+  cli_alert_info("Update 1: The underline has been removed for converged runs (green).")
+  cli_alert_info("Update 2: Runs that showed INFES but finally converged are now displayed in the same way (now green, previously blue).")
   cli_alert_info("Did you know? {sample(hints, 1)}")
-  
+
   # retrieve options (flags) and positional arguments (paths)
   opt  <- arguments$options
   paths <- arguments$args
@@ -154,7 +156,7 @@ commandLineInterface <- function(argv) {
       myruns <- myruns[-deleteruns]
       runnames <- runnames[-deleteruns]
     }
-    
+
     # add REMIND-MAgPIE coupled runs where run directory is not the output directory
     # these lines also drop all other slurm jobs such as remind preprocessing etc.
     if (length(myruns) > 0) {
@@ -172,7 +174,7 @@ commandLineInterface <- function(argv) {
       myruns <- myruns[file.exists(myruns)] # keep only existing paths
       myruns <- sort(unique(myruns[!is.na(myruns)]))
     }
-    
+
     # exit with the proper message
     if (length(myruns) == 0) {
       if (opt$daysback < 1) {
@@ -182,9 +184,9 @@ commandLineInterface <- function(argv) {
       }
       quit(save = 'no', status = 0)
     }
-    
+
     runfolders <- myruns
-    
+
   } else {
     # OPTION B: create list with run folders from path supplied by user or AMTs
     runfolders <- NULL
@@ -198,18 +200,18 @@ commandLineInterface <- function(argv) {
         runfolders <- c(runfolders, list.dirs(dir, recursive = FALSE))
       }
     }
-    
+
   }
 
   # filter coupling iterations
   if (opt$magpie & !is.null(runfolders)) {
     # add magpie run folders if 'magpie/output' exists inside current folder
     if (dir.exists(file.path("magpie", "output"))) runfolders <- c(runfolders, file.path("magpie", "output"))
-    
+
     # find iterations using only the basename (to ignore rem|mag if they exist in the path before the basename)
     IndexOfcoupledRuns <- grepl("(^C_)|(-(rem|mag)-[0-9]+$)", basename(runfolders))
     runfolders <- runfolders[IndexOfcoupledRuns]
-    
+
     # keep last iteration only
     if (opt$last) {
       lastdirs <- NULL
@@ -218,20 +220,20 @@ commandLineInterface <- function(argv) {
       }
       runfolders <- lastdirs
     }
-    
+
     if (is.null(runfolders)) {
       cli_alert_warning("No coupled runs found")
       quit(save = 'no', status = 0)
     }
   }
-   
+
   # =============================================
   #   print table (runstatus or sanity)
   # =============================================
-  
+
   # filter runs. If not changed by the user the default pattern '.*' filters all
   runfolders <- grep(opt$filter, runfolders, value = TRUE)
-  
+
   # sort strings containing embedded numbers so that the numbers are numerically sorted rather than sorted by character value
   runfolders <- runfolders[stringi::stri_order(basename(normalizePath(runfolders)), numeric = TRUE)]
 
@@ -242,15 +244,15 @@ commandLineInterface <- function(argv) {
     if (length(runfolders) > 40 && opt$filter == ".*" && !opt$prompt) {
       cli_alert_info("To reduce the number of runs, filter the runs with -f REGEX or select manually from the list with -p.")
     }
-    
+
     # list all runs found and prompt the user to select
     if (opt$prompt) {
-      runfolders <- gms::chooseFromList(runfolders, type = "folders") 
+      runfolders <- gms::chooseFromList(runfolders, type = "folders")
     }
-    
+
     cli_alert_info("Runs found: {length(runfolders)}")
 
-    # decide whether to display sanity cheks or runstatus  
+    # decide whether to display sanity cheks or runstatus
     if (opt$sanity) {
       modelstats::getSanityChecks(runfolders)
     } else {

--- a/R/loopRuns.R
+++ b/R/loopRuns.R
@@ -27,8 +27,8 @@ loopRuns <- function(mydir, user = NULL, colors = TRUE, sortbytime = TRUE) {
   orange <- make_style("orange")
   if (colors) {
     cat("# Color code: ", yellow("pending"), "/", yellow("startup"), ", ", cyan("running"), ", ",
-        underline(green("converged")), ", ", blue("converged (had INFES)"), ", ", orange("no mif"), ", ",
-        green("finished"), ", ", magenta("conopt stalled?"), ", ", red("error"), ".\n\n", sep = "")
+        green("converged"), "/", green("finished"), ", ", orange("no mif"), ", ",
+        magenta("conopt stalled?"), ", ", red("error"), ".\n\n", sep = "")
   }
   a <- file.info(mydir)
   a <- a[a[, "isdir"] == TRUE, ]
@@ -115,11 +115,11 @@ loopRuns <- function(mydir, user = NULL, colors = TRUE, sortbytime = TRUE) {
       } else if (! status[["jobInSLURM"]] == "no" && !status[["jobInSLURM"]] == "NA") {
         cat(cyan(out))
       } else if (status[["Conv"]] == "converged (had INFES)" && ! status[["Mif"]] == "no") {
-        cat(blue(out))
+        cat(green(out))
       } else if (grepl("not_converged|Execution erro|Compilation er|interrupted|Intermed Infes", status[["RunStatus"]])) {
         cat(red(out))
       } else if (status[["Conv"]] %in% c("converged", "Clb_converged") && ! status[["Mif"]] == "no") {
-        cat(underline(green(out)))
+        cat(green(out))
       } else if (grepl("2: Locally Optimal", status[["modelstat"]]) && ! grepl("nash", status[["RunType"]])) {
         cat(green(out))
       } else if (status[["Mif"]] == "no" && status[["Conv"]] %in% c("converged", "Clb_converged", "converged (had INFES)")) {

--- a/R/loopRuns.R
+++ b/R/loopRuns.R
@@ -92,7 +92,7 @@ loopRuns <- function(mydir, user = NULL, colors = TRUE, sortbytime = TRUE) {
       } else if (grepl("not_converged|Execution erro|Compilation er|missing|interrupted|Abort", status[["RunStatus"]])) {
         cat(red(out))
       } else if (grepl("converged|Clb_converged", status[["RunStatus"]])) {
-        cat(underline(green(out)))
+        cat(green(out))
       } else if ((grepl("222", status[["modelstat"]]) && ! grepl(".", status[["modelstat"]], fixed = TRUE))
                  || status[["modelstat"]] == "2: Locally Optimal") {
         cat(green(out))

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.29.3**
+R package **modelstats**, version **0.29.4**
 
    [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2026). "modelstats: Run Analysis Tools." Version: 0.29.3, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2026). "modelstats: Run Analysis Tools." Version: 0.29.4, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,9 +55,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
-  date = {2026-05-06},
+  date = {2026-05-11},
   year = {2026},
   url = {https://github.com/pik-piam/modelstats},
-  note = {Version: 0.29.3},
+  note = {Version: 0.29.4},
 }
 ```

--- a/man/commandLineInterface.Rd
+++ b/man/commandLineInterface.Rd
@@ -14,7 +14,7 @@ A string containing the status or sanity table.
 }
 \description{
 This function is made to be called by the rs tool. It takes the command line arguments
-supplied by the user when calling rs, evaluates them, and according to them prepares the 
+supplied by the user when calling rs, evaluates them, and according to them prepares the
 arguments finally passed to loopRuns or getSanityChecks.
 }
 \author{

--- a/man/modelstats-package.Rd
+++ b/man/modelstats-package.Rd
@@ -21,7 +21,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Anastasis Giannousakis \email{giannou@pik-potsdam.de}
   \item Oliver Richters
 }
 


### PR DESCRIPTION
Reduce number of styles in order to improve readibility:
1. Remove underline from converged runs and display them simply in green
2. Use the same format (green) for runs that had INFES but finally converged