### PR TITLE
Update flag to match remind change

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '6180600'
+ValidationKey: '6223476'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'modelstats: Run Analysis Tools'
-version: 0.30.0
-date-released: '2026-05-29'
+version: 0.30.1
+date-released: '2026-08-11'
 abstract: A collection of tools to analyze model runs.
 authors:
 - family-names: Giannousakis

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: modelstats
 Type: Package
 Title: Run Analysis Tools
-Version: 0.30.0
-Date: 2026-05-29
+Version: 0.30.1
+Date: 2026-08-11
 Authors@R: c(
     person("Anastasis", "Giannousakis", email = "giannou@pik-potsdam.de", role = c("aut","cre")),
     person("Oliver", "Richters", role = "aut")

--- a/R/modeltests.R
+++ b/R/modeltests.R
@@ -345,7 +345,7 @@ evaluateRuns <- function(model, # nolint: cyclocomp_linter.
                            " --error=", fullPathToThisRun, "/", outFileName, ".out",
                            " --mail-type=END --time=200 --mem-per-cpu=8000",
                            " --wrap=\"Rscript scripts/cs2/run_compareScenarios2.R",
-                           " outputDirs=", paste(c(fullPathToThisRun, fullPathToLastRun), collapse = ","),
+                           " outputdirs=", paste(c(fullPathToThisRun, fullPathToLastRun), collapse = ","),
                            " profileName=default",
                            " outFileName=", outFileName,
                            "; ", "mv ", outFileName, ".pdf ", fullPathToThisRun,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Run Analysis Tools
 
-R package **modelstats**, version **0.30.0**
+R package **modelstats**, version **0.30.1**
 
    [![R build status](https://github.com/pik-piam/modelstats/workflows/check/badge.svg)](https://github.com/pik-piam/modelstats/actions) [![codecov](https://codecov.io/gh/pik-piam/modelstats/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/modelstats) [![r-universe](https://pik-piam.r-universe.dev/badges/modelstats)](https://pik-piam.r-universe.dev/builds)
 
@@ -47,7 +47,7 @@ In case of questions / problems please contact Anastasis Giannousakis <giannou@p
 
 To cite package **modelstats** in publications use:
 
-Giannousakis A, Richters O (2026). "modelstats: Run Analysis Tools." Version: 0.30.0, <https://github.com/pik-piam/modelstats>.
+Giannousakis A, Richters O (2026). "modelstats: Run Analysis Tools." Version: 0.30.1, <https://github.com/pik-piam/modelstats>.
 
 A BibTeX entry for LaTeX users is
 
@@ -55,9 +55,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {modelstats: Run Analysis Tools},
   author = {Anastasis Giannousakis and Oliver Richters},
-  date = {2026-05-29},
+  date = {2026-08-11},
   year = {2026},
   url = {https://github.com/pik-piam/modelstats},
-  note = {Version: 0.30.0},
+  note = {Version: 0.30.1},
 }
 ```


### PR DESCRIPTION
In https://github.com/remindmodel/remind/pull/2413 I harmonized some flags and forgot to update here as well. This is responsible for the recent AMT failures.

I haven't run any tests yet.